### PR TITLE
Add asrclient support for mutliple, builtin and remote grammars

### DIFF
--- a/data/params_default.txt
+++ b/data/params_default.txt
@@ -1,0 +1,6 @@
+No-Input-Timeout: 5000
+Recognition-Timeout: 20000
+Speech-Complete-Timeout: 400
+DTMF-Term-Timeout: 3000
+DTMF-Interdigit-Timeout: 3000
+Confidence-Threshold: 0.5

--- a/platforms/asr-client/src/main.c
+++ b/platforms/asr-client/src/main.c
@@ -49,6 +49,7 @@ typedef struct {
 /** Thread function to run ASR scenario in */
 static void* APR_THREAD_FUNC asr_session_run(apr_thread_t *thread, void *data)
 {
+	const char *result;
 	asr_params_t *params = data;
 	asr_session_t *session = asr_session_create(params->engine,params->profile);
 	if(session) {
@@ -65,7 +66,7 @@ static void* APR_THREAD_FUNC asr_session_run(apr_thread_t *thread, void *data)
 		}
 
 		// Do recognition
-		const char *result = asr_session_file_recognize(session,params->grammar_file,params->input_file, params->params_file,params->sendSetParams,params->sendGetParams);
+		result = asr_session_file_recognize(session,params->grammar_file,params->input_file,params->params_file,params->sendSetParams,params->sendGetParams);
 		if(result) {
 			printf("Recog Result [%s]",result);
 		}

--- a/platforms/asr-client/src/main.c
+++ b/platforms/asr-client/src/main.c
@@ -20,6 +20,11 @@
 #include <apr_file_info.h>
 #include <apr_thread_proc.h>
 #include "asr_engine.h"
+#include "asr_engine_common.h"
+
+#define DEFAULT_GRAMMAR_FILE "grammar.xml"
+#define DEFAULT_INPUT_FILE "one-8kHz.pcm"
+#define DEFAULT_PROFILE "uni2"
 
 typedef struct {
 	const char        *root_dir_path;
@@ -33,7 +38,10 @@ typedef struct {
 	const char        *grammar_file;
 	const char        *input_file;
 	const char        *profile;
-	
+	const char        *params_file;
+	apt_bool_t         sendSetParams;
+	apt_bool_t         sendGetParams;
+
 	apr_thread_t      *thread;
 	apr_pool_t        *pool;
 } asr_params_t;
@@ -44,11 +52,33 @@ static void* APR_THREAD_FUNC asr_session_run(apr_thread_t *thread, void *data)
 	asr_params_t *params = data;
 	asr_session_t *session = asr_session_create(params->engine,params->profile);
 	if(session) {
-		const char *result = asr_session_file_recognize(session,params->grammar_file,params->input_file);
+		ParameterSet* initial_params = NULL;
+		ParameterSet* final_params = NULL;
+		if(params->sendGetParams) {
+			// Get all default parameters from session
+			initial_params = asr_session_get_all_params(session);
+		}
+
+		if(params->sendSetParams) {
+			// Set parameters from param file
+			asr_session_set_param(session,params->params_file,NULL,NULL);
+		}
+
+		// Do recognition
+		const char *result = asr_session_file_recognize(session,params->grammar_file,params->input_file, params->params_file,params->sendSetParams,params->sendGetParams);
 		if(result) {
 			printf("Recog Result [%s]",result);
 		}
 
+		if(params->sendGetParams) {
+			// Get all session parameters after recognition
+			final_params = asr_session_get_all_params(session);
+
+			if(initial_params->n_best_list_length != final_params->n_best_list_length) {
+				// this is just a sample. The returned ParameterSet may be useful in different test scenarios.
+				printf("Parameters do not match.");
+			}
+		}
 		asr_session_destroy(session);
 	}
 
@@ -58,11 +88,11 @@ static void* APR_THREAD_FUNC asr_session_run(apr_thread_t *thread, void *data)
 }
 
 /** Launch demo ASR session */
-static apt_bool_t asr_session_launch(asr_engine_t *engine, const char *grammar_file, const char *input_file, const char *profile)
+static apt_bool_t asr_session_launch(asr_engine_t *engine, const char *grammar_file, const char *input_file, const char *profile, const char* params_file, apt_bool_t sendSetParams, apt_bool_t sendGetParams)
 {
 	apr_pool_t *pool;
 	asr_params_t *params;
-	
+
 	/* create pool to allocate params from */
 	apr_pool_create(&pool,NULL);
 	params = apr_palloc(pool,sizeof(asr_params_t));
@@ -73,29 +103,39 @@ static apt_bool_t asr_session_launch(asr_engine_t *engine, const char *grammar_f
 		params->grammar_file = apr_pstrdup(pool,grammar_file);
 	}
 	else {
-		params->grammar_file = "grammar.xml";
+		params->grammar_file = DEFAULT_GRAMMAR_FILE;
 	}
 
 	if(input_file) {
 		params->input_file = apr_pstrdup(pool,input_file);
 	}
 	else {
-		params->input_file = "one-8kHz.pcm";
+		params->input_file = DEFAULT_INPUT_FILE;
 	}
-	
-	if(profile) {
+
+	if(profile && profile[0] != '-') {
 		params->profile = apr_pstrdup(pool,profile);
 	}
 	else {
-		params->profile = "uni2";
+		params->profile = DEFAULT_PROFILE;
 	}
+
+	if(params_file && params_file[0] != '-') {
+		params->params_file = apr_pstrdup(pool,params_file);
+	}
+	else {
+		params->params_file = NULL;
+	}
+
+	params->sendSetParams = sendSetParams;
+	params->sendGetParams = sendGetParams;
 
 	/* Launch a thread to run demo ASR session in */
 	if(apr_thread_create(&params->thread,NULL,asr_session_run,params,pool) != APR_SUCCESS) {
 		apr_pool_destroy(pool);
 		return FALSE;
 	}
-	
+
 	return TRUE;
 }
 
@@ -109,10 +149,24 @@ static apt_bool_t cmdline_process(asr_engine_t *engine, char *cmdline)
 		return running;
 
 	if(strcasecmp(name,"run") == 0) {
+		apt_bool_t sendSetParams = FALSE;
+		apt_bool_t sendGetParams = FALSE;
+
 		char *grammar = apr_strtok(NULL, " ", &last);
 		char *input = apr_strtok(NULL, " ", &last);
 		char *profile = apr_strtok(NULL, " ", &last);
-		asr_session_launch(engine,grammar,input,profile);
+		char *params_file = apr_strtok(NULL, " ", &last);
+		char *send_set_params = apr_strtok(NULL, " ", &last);
+		char *send_get_params = apr_strtok(NULL, " ", &last);
+
+		if(send_set_params != NULL && strcasecmp(send_set_params,"SET") == 0) {
+			sendSetParams = TRUE;
+		}
+		if(send_get_params != NULL && strcasecmp(send_get_params, "GET") == 0) {
+			sendGetParams = TRUE;
+		}
+
+		asr_session_launch(engine,grammar,input,profile,params_file,sendSetParams,sendGetParams);
 	}
 	else if(strcasecmp(name,"loglevel") == 0) {
 		char *priority = apr_strtok(NULL, " ", &last);
@@ -125,16 +179,52 @@ static apt_bool_t cmdline_process(asr_engine_t *engine, char *cmdline)
 	}
 	else if(strcasecmp(name,"help") == 0) {
 		printf("usage:\n"
-			"\n- run [grammar_file] [audio_input_file] [profile_name] (run demo asr client)\n"
-			"       grammar_file is the name of grammar file, (path is relative to data dir)\n"
-			"       audio_input_file is the name of audio file, (path is relative to data dir)\n"
-			"       profile_name is one of 'uni2', 'uni1', ...\n"
-			"\n       examples: \n"
-			"           run\n"
-			"           run grammar.xml one.pcm\n"
-			"           run grammar.xml one.pcm uni1\n"
-		    "\n- loglevel [level] (set loglevel, one of 0,1...7)\n"
-		    "\n- quit, exit\n");
+			"Run demo ASR client\n"
+			"Run grammar_uri_list audio_input_file [profile_name | -] [params_file | -] [set | -] [get | -]\n"
+			"\n"
+			"    grammar_uri_list is the name of a grammar file (path is relative to data dir)\n"
+			"      (default is " DEFAULT_GRAMMAR_FILE ")\n"
+			"      or a comma separated list of grammar uris, where grammar_uri may be one of the following:\n"
+			"       - http:// or https:// - grammars hosted on a web server and accessible by http/s\n"
+			"       - builtin: - grammar is a VoiceXML builtin grammar like builtin:grammar/boolean\n"
+			"       - supported prorpietary grammar URIs\n"
+			"       - (no URI prefix) - grammar file is read from local data folder.\n"
+			"      or a comma separated list of weighted grammars, each in text/grammar-ref-list format\n"
+			"\n"
+			"    audio_input_file is the name of audio file to process, (path is relative to data dir). \n"
+			"      headerless PCM files are supported as well as WAV files with RIFF headers.\n"
+			"      (default is " DEFAULT_INPUT_FILE ")\n"
+			"\n"
+			"    profile_name is the configured client-profile, like one of 'uni2', 'uni1', ...\n"
+			"      (default is " DEFAULT_PROFILE ")\n"
+			"\n"
+			"    params_file is a path to a file of MRCP headers. A dash (-) may be used to skip this parameter.\n"
+			"        Example headers are:\n"
+			"          N-Best-List-Length: 3\n"
+			"          No-Input-Timeout: 3000\n"
+			"          Speech-Complete-Timeout: 500\n"
+			"      (default is no parameter file. In this case the ASR defaults are used)\n"
+			"\n"
+			"   set - send parameter_file as headers in MRCP SET-PARAMS method, otherwise\n"
+			"        parameters are sent as headers in the MRCP RECOGNIZE method \n"
+			"\n"
+			"   get - send MRCP GET-PARAMS method before and after recognition\n"
+			"\n"
+			"   example: \n"
+			"      run grammar.xml one-8kHz.pcm uni2 params_default.txt set get\n"
+			"   other examples: \n"
+			"      run grammar.xml one.wav\n"
+			"      run builtin:grammar/boolean yes.wav\n"
+			"      run grammar.xml,builtin:grammar/boolean,http://example.com/operator.grxml speak_to_representative.wav\n"
+			"      run operator.grxml speak_to_representative.wav uni2\n"
+			"      run builtin:grammar/boolean yes.pcm uni2\n"
+			"      run builtin:grammar/boolean yes.wav - params.txt set get\n"
+			"      run http://example.com/grammars/grammar.grxml one.wav uni2\n"
+			"      run <http://localhost/grammars/grammar.grxml>;weight=\"2.0\",<builtin:grammar/boolean>;weight=\"0.75\"\n"
+			"\n"
+			"- loglevel [level] (set loglevel, one of 0,1...7)\n"
+			"\n"
+			"- quit, exit\n");
 	}
 	else {
 		printf("unknown command: %s (input help for usage)\n",name);

--- a/platforms/libasr-client/CMakeLists.txt
+++ b/platforms/libasr-client/CMakeLists.txt
@@ -4,6 +4,7 @@ project (asrclient)
 # Set header files
 set (ASR_CLIENT_HEADERS
 	include/asr_engine.h
+	include/asr_engine_common.h
 )
 source_group ("include" FILES ${ASR_CLIENT_HEADERS})
 

--- a/platforms/libasr-client/Makefile.am
+++ b/platforms/libasr-client/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS                 = -I$(top_srcdir)/platforms/libasr-client/include \
 
 lib_LTLIBRARIES             = libasrclient.la
 
-include_HEADERS             = include/asr_engine.h
+include_HEADERS             = include/asr_engine.h include/asr_engine_common.h
 libasrclient_la_SOURCES     = src/asr_engine.c
 libasrclient_la_LIBADD      = $(top_builddir)/platforms/libunimrcp-client/libunimrcpclient.la
 libasrclient_la_LDFLAGS     = $(UNIMRCP_CLIENTLIB_OPTS)

--- a/platforms/libasr-client/include/asr_engine.h
+++ b/platforms/libasr-client/include/asr_engine.h
@@ -142,10 +142,10 @@ ASR_CLIENT_DECLARE(asr_session_t*) asr_session_create(asr_engine_t *engine, cons
  * @return the recognition result (input element of NLSML content)
  */
 ASR_CLIENT_DECLARE(const char*) asr_session_file_recognize(
-									asr_session_t *session, 
-									const char *grammar_file, 
+									asr_session_t *session,
+									const char *grammar_file,
 									const char *input_file,
-									const char* set_params_file,
+									const char *set_params_file,
 									apt_bool_t sendSetParams,
 									apt_bool_t sendGetParams);
 
@@ -161,7 +161,7 @@ ASR_CLIENT_DECLARE(const char*) asr_session_file_recognize(
  *         asr_session_stream_write() function calls.
  */
 ASR_CLIENT_DECLARE(const char*) asr_session_stream_recognize(
-									asr_session_t *session, 
+									asr_session_t *session,
 									const char *grammar_file);
 
 /**
@@ -177,9 +177,9 @@ ASR_CLIENT_DECLARE(apt_bool_t) asr_session_stream_write(
 
 ASR_CLIENT_DECLARE(apt_bool_t) asr_session_set_param(
 									asr_session_t *session,
-									const char* set_params_file,
-									const char* param_name,
-									const char* param_value);
+									const char *set_params_file,
+									const char *param_name,
+									const char *param_value);
 
 ASR_CLIENT_DECLARE(ParameterSet*) asr_session_get_all_params(asr_session_t *session);
 

--- a/platforms/libasr-client/include/asr_engine_common.h
+++ b/platforms/libasr-client/include/asr_engine_common.h
@@ -61,4 +61,3 @@ typedef struct {
 } RecognitionResult;
 
 #endif /* ASR_ENGINE_COMMON_H */
-

--- a/platforms/libasr-client/include/asr_engine_common.h
+++ b/platforms/libasr-client/include/asr_engine_common.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2009-2015 Arsen Chaloyan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ASR_ENGINE_COMMON_H
+#define ASR_ENGINE_COMMON_H
+
+#include <apt.h>
+
+#include "mrcp_recog_resource.h"
+
+/**
+ * @file asr_engine_common.h
+ * @brief Put into spearate include file to ease access through SWIG or
+ * other interop wrappers.
+ */
+
+typedef struct {
+	float	confidence_threshold;
+	float	sensitivity_level;
+	float	speed_vs_accuracy;
+	long	n_best_list_length;
+	long	no_input_timeout;
+	long	recognition_timeout;
+	char   *recognizer_context_block;
+	long	speech_complete_timeout;
+	long	speech_incomplete_timeout;
+	long	dtmf_interdigit_timeout;
+	long	dtmf_term_timeout;
+	char	dtmf_term_char;
+	int	save_waveform;
+	char   *speech_language;
+	char   *media_type;
+	char   *recognition_mode;
+	long	hotword_max_duration;
+	long	hotword_min_duration;
+	long	dtmf_buffer_time;
+	int	early_no_match;
+} ParameterSet;
+
+typedef struct {
+	mrcp_recognizer_event_id	event_id;
+	int				completion_cause_code;
+	const char		       *completion_cause_name;
+	apt_bool_t			is_recognizing;
+	apt_bool_t			completion_success;
+	const char		       *result;
+	const char		       *body;
+} RecognitionResult;
+
+#endif /* ASR_ENGINE_COMMON_H */
+

--- a/platforms/libasr-client/libasrclient.vcproj
+++ b/platforms/libasr-client/libasrclient.vcproj
@@ -292,6 +292,10 @@
 				RelativePath=".\include\asr_engine.h"
 				>
 			</File>
+			<File
+				RelativePath=".\include\asr_engine_common.h"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="src"

--- a/platforms/libasr-client/libasrclient.vcxproj
+++ b/platforms/libasr-client/libasrclient.vcxproj
@@ -132,6 +132,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="include\asr_engine.h" />
+    <ClInclude Include="include\asr_engine_common.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\asr_engine.c" />

--- a/platforms/libasr-client/src/asr_engine.c
+++ b/platforms/libasr-client/src/asr_engine.c
@@ -774,6 +774,20 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_N_BEST_LIST_LENGTH);
 		}
 	}
+	if(apr_strnatcasecmp(pname,"New-Audio-Channel") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_NEW_AUDIO_CHANNEL);
+		}
+		else {
+			if(apr_strnatcasecmp(pvalue,"true") == 0) {
+				recog_header->new_audio_channel = TRUE;
+			}
+			else {
+				recog_header->new_audio_channel = FALSE;
+			}
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_NEW_AUDIO_CHANNEL);
+		}
+	}
 	if(apr_strnatcasecmp(pname,"No-Input-Timeout") == 0) {
 		if(0 == strlen(pvalue)) {
 			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_NO_INPUT_TIMEOUT);
@@ -956,16 +970,18 @@ static apt_bool_t set_param_from_file(
 			if(str != NULL) {
 				val = apr_strtok(str,":",&last);
 				if (val != NULL) {
-					const char *pname = NULL, *pvalue = NULL;
+					const char *pname = NULL;
+					const char *pvalue = NULL;
+
 					apr_collapse_spaces(val,val);
 					pname = val;
-					while (val && pvalue == NULL) {
-						val = apr_strtok(NULL,":",&last);
+
+					val = apr_strtok(NULL,":",&last);
+					if(val != NULL) {
 						apr_collapse_spaces(val,val);
 						pvalue = val;
+						set_individual_param(mrcp_message,recog_header,pname,pvalue);
 					}
-
-					set_individual_param(mrcp_message,recog_header,pname,pvalue);
 				}
 			}
 		} while(rv != APR_EOF);

--- a/platforms/libasr-client/src/asr_engine.c
+++ b/platforms/libasr-client/src/asr_engine.c
@@ -624,10 +624,10 @@ ASR_CLIENT_DECLARE(asr_session_t*) asr_session_create(asr_engine_t *engine, cons
 
 /** Initiate recognition based on specified grammar and input file */
 ASR_CLIENT_DECLARE(const char*) asr_session_file_recognize(
-									asr_session_t *asr_session, 
-									const char *grammar_file, 
+									asr_session_t *asr_session,
+									const char *grammar_file,
 									const char *input_file,
-									const char* set_params_file,
+									const char *set_params_file,
 									apt_bool_t sendSetParams,
 									apt_bool_t sendGetParams)
 {
@@ -727,7 +727,7 @@ ASR_CLIENT_DECLARE(apt_bool_t) asr_session_define_grammar(
 	return (MRCP_STATUS_CODE_SUCCESS == status_code || MRCP_STATUS_CODE_SUCCESS_WITH_IGNORE == status_code);
 }
 
-static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_header_t *recog_header, const char* pname, const char* pvalue)
+static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_header_t *recog_header, const char *pname, const char *pvalue)
 {
 	int no_input_timeout, n_best_list_length, recognition_timeout;
 	float confidence_threshold, sensitivity_level, speed_vs_accuracy;
@@ -755,7 +755,7 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 		}
 	}
 	if(apr_strnatcasecmp(pname,"Speed-Vs-Accuracy") == 0) {
-		if(0 == strlen(pvalue))	{
+		if(0 == strlen(pvalue)) {
 			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SPEED_VS_ACCURACY);
 		}
 		else {
@@ -775,7 +775,7 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 		}
 	}
 	if(apr_strnatcasecmp(pname,"No-Input-Timeout") == 0) {
-		if(0 == strlen(pvalue))	{
+		if(0 == strlen(pvalue)) {
 			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_NO_INPUT_TIMEOUT);
 		}
 		else {
@@ -927,7 +927,6 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 	}
 	return NULL;
 }
-
 
 static apt_bool_t set_param_from_file(
 								asr_session_t *asr_session,
@@ -1170,7 +1169,6 @@ ASR_CLIENT_DECLARE(apt_bool_t) asr_engine_log_priority_set(apt_log_priority_e lo
 }
 
 
-
 /** Handle MRCP headers (Parameters) **/
 
 /** Create SET-PARAM request */
@@ -1210,9 +1208,9 @@ static mrcp_message_t* get_param_message_create(asr_session_t *asr_session)
 
 ASR_CLIENT_DECLARE(apt_bool_t) asr_session_set_param(
 							asr_session_t *asr_session,
-							const char* set_params_file,
-							const char* param_name,
-							const char* param_value)
+							const char *set_params_file,
+							const char *param_name,
+							const char *param_value)
 {
 	const mrcp_app_message_t *app_message = NULL;
 	mrcp_message_t *mrcp_message = set_param_message_create(asr_session,set_params_file,param_name,param_value);
@@ -1301,4 +1299,3 @@ ASR_CLIENT_DECLARE(ParameterSet*) asr_session_get_all_params(asr_session_t *asr_
 
 	return p;
 }
-

--- a/platforms/libasr-client/src/asr_engine.c
+++ b/platforms/libasr-client/src/asr_engine.c
@@ -733,14 +733,13 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 	float confidence_threshold, sensitivity_level, speed_vs_accuracy;
 	int speech_complete_timeout, speech_incomplete_timeout, dtmf_interdigit_timeout, dtmf_term_timeout;
 	int hotword_max_duration, hotword_min_duration;
-	char *stopptr;
 
 	if(apr_strnatcasecmp(pname,"Confidence-Threshold") == 0) {
 		if(0 == strlen(pvalue)) {
 			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_CONFIDENCE_THRESHOLD);
 		}
 		else {
-			confidence_threshold = strtof(pvalue,&stopptr);
+			confidence_threshold = (float) atof(pvalue);
 			recog_header->confidence_threshold = confidence_threshold;
 			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_CONFIDENCE_THRESHOLD);
 		}
@@ -750,7 +749,7 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SENSITIVITY_LEVEL);
 		}
 		else {
-			sensitivity_level = strtof(pvalue,&stopptr);
+			sensitivity_level = (float) atof(pvalue);
 			recog_header->sensitivity_level = sensitivity_level;
 			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SENSITIVITY_LEVEL);
 		}
@@ -760,7 +759,7 @@ static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_heade
 			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SPEED_VS_ACCURACY);
 		}
 		else {
-			speed_vs_accuracy = strtof(pvalue,&stopptr);
+			speed_vs_accuracy = (float) atof(pvalue);
 			recog_header->speed_vs_accuracy = speed_vs_accuracy;
 			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SPEED_VS_ACCURACY);
 		}

--- a/platforms/libasr-client/src/asr_engine.c
+++ b/platforms/libasr-client/src/asr_engine.c
@@ -17,72 +17,43 @@
 #include <stdlib.h>
 
 /* APR includes */
-#include <apr_thread_cond.h>
 #include <apr_thread_proc.h>
-
 /* Common includes */
 #include "unimrcp_client.h"
-#include "mrcp_application.h"
 #include "mrcp_message.h"
 #include "mrcp_generic_header.h"
-/* Recognizer includes */
-#include "mrcp_recog_header.h"
-#include "mrcp_recog_resource.h"
-/* MPF includes */
-#include <mpf_frame_buffer.h>
+#include "mrcp_client_session.h"
 /* APT includes */
 #include "apt_nlsml_doc.h"
-#include "apt_log.h"
 #include "apt_pool.h"
 
 #include "asr_engine.h"
 
-typedef enum {
-	INPUT_MODE_NONE,
-	INPUT_MODE_FILE,
-	INPUT_MODE_STREAM
-} input_mode_e;
+#define LINE_BUFFER 1024
+#define WAVE_HEADER_LEN 44
 
-/** ASR engine on top of UniMRCP client stack */
-struct asr_engine_t {
-	/** MRCP client stack */
-	mrcp_client_t      *mrcp_client;
-	/** MRCP client stack */
-	mrcp_application_t *mrcp_app;
-	/** Memory pool */
-	apr_pool_t         *pool;
-};
+const char *STANDARD_GRAMMAR_URI_SCHEMES = "http:,https:,file:,builtin:";
+// udpate note - proprietary grammar URI schemes may be added as comma separated list
+const char *PROPRIETARY_GRAMMAR_URI_SCHEMES = NULL; // ",xxxx:,yyyy:";
+// udpate note - end proprietary grammar URI schemes
 
+int startswith(const char *pre, const char *str) {
+	return strncmp(pre,str,strlen(pre)) == 0;
+}
 
-/** ASR session on top of UniMRCP session/channel */
-struct asr_session_t {
-	/** Back pointer to engine */
-	asr_engine_t             *engine;
-	/** MRCP session */
-	mrcp_session_t           *mrcp_session;
-	/** MRCP channel */
-	mrcp_channel_t           *mrcp_channel;
-	/** RECOGNITION-COMPLETE message  */
-	mrcp_message_t           *recog_complete;
+int endsWith(const char *str, const char *suffix) {
+	size_t lenstr, lensuffix;
 
-	/** Input mode (either file or stream) */
-	input_mode_e              input_mode;
-	/** File to read media frames from */
-	FILE                     *audio_in;
-	/* Buffer of media frames */
-	mpf_frame_buffer_t       *media_buffer;
-	/** Streaming is in-progress */
-	apt_bool_t                streaming;
+	if (!str || !suffix)
+		return 0;
 
-	/** Conditional wait object */
-	apr_thread_cond_t        *wait_object;
-	/** Mutex of the wait object */
-	apr_thread_mutex_t       *mutex;
+	lenstr = strlen(str);
+	lensuffix = strlen(suffix);
+	if (lensuffix > lenstr)
+		return 0;
 
-	/** Message sent from client stack */
-	const mrcp_app_message_t *app_message;
-};
-
+	return strncmp(str+lenstr-lensuffix,suffix,lensuffix) == 0;
+}
 
 /** Declaration of recognizer audio stream methods */
 static apt_bool_t asr_stream_read(mpf_audio_stream_t *stream, mpf_frame_t *frame);
@@ -125,6 +96,7 @@ ASR_CLIENT_DECLARE(asr_engine_t*) asr_engine_create(
 	/* create singleton logger */
 	apt_log_instance_create(log_output,log_priority,pool);
 
+	// udpate note - todo - this may be out of date from 1.6
 	if(apt_log_output_mode_check(APT_LOG_OUTPUT_FILE) == TRUE) {
 		/* open the log file */
 		const char *log_dir_path = apt_dir_layout_path_get(dir_layout,APT_LAYOUT_LOG_DIR);
@@ -150,7 +122,7 @@ ASR_CLIENT_DECLARE(asr_engine_t*) asr_engine_create(
 		apr_pool_destroy(pool);
 		return NULL;
 	}
-	
+
 	/* create an application */
 	mrcp_app = mrcp_application_create(
 								app_message_handler,
@@ -229,7 +201,7 @@ static apt_bool_t asr_session_destroy_ex(asr_session_t *asr_session, apt_bool_t 
 		mpf_frame_buffer_destroy(asr_session->media_buffer);
 		asr_session->media_buffer = NULL;
 	}
-	
+
 	return mrcp_application_session_destroy(asr_session->mrcp_session);
 }
 
@@ -239,6 +211,8 @@ static apt_bool_t asr_input_file_open(asr_session_t *asr_session, const char *in
 	const apt_dir_layout_t *dir_layout = mrcp_application_dir_layout_get(asr_session->engine->mrcp_app);
 	apr_pool_t *pool = mrcp_application_session_pool_get(asr_session->mrcp_session);
 	char *input_file_path = apt_datadir_filepath_get(dir_layout,input_file,pool);
+	/** udpate note - if this is a RIFF file, read passed the wav file header **/
+	char header_buf[WAVE_HEADER_LEN+1] = "";
 	if(!input_file_path) {
 		return FALSE;
 	}
@@ -249,6 +223,15 @@ static apt_bool_t asr_input_file_open(asr_session_t *asr_session, const char *in
 	}
 
 	asr_session->audio_in = fopen(input_file_path,"rb");
+
+	if(asr_session->audio_in != NULL) {
+		if((fread(header_buf,1,WAVE_HEADER_LEN,asr_session->audio_in) != WAVE_HEADER_LEN) ||
+			(strncmp(header_buf,"RIFF",4) != 0)) {
+			rewind(asr_session->audio_in); // rewind if no wave header
+		}
+	}
+	// udpate note - end skip RIFF header
+
 	if(!asr_session->audio_in) {
 		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Cannot Open [%s]",input_file_path);
 		return FALSE;
@@ -284,7 +267,7 @@ static apt_bool_t asr_stream_read(mpf_audio_stream_t *stream, mpf_frame_t *frame
 }
 
 /** Create DEFINE-GRAMMAR request */
-static mrcp_message_t* define_grammar_message_create(asr_session_t *asr_session, const char *grammar_file_name)
+static mrcp_message_t* define_grammar_message_create(asr_session_t *asr_session, const char *grammar_file_name, int i)
 {
 	/* create MRCP message */
 	mrcp_message_t *mrcp_message = mrcp_application_message_create(
@@ -297,48 +280,96 @@ static mrcp_message_t* define_grammar_message_create(asr_session_t *asr_session,
 		/* set message body */
 		const apt_dir_layout_t *dir_layout = mrcp_application_dir_layout_get(asr_session->engine->mrcp_app);
 		apr_pool_t *pool = mrcp_application_session_pool_get(asr_session->mrcp_session);
-		char *grammar_file_path = apt_datadir_filepath_get(dir_layout,grammar_file_name,pool);
-		if(grammar_file_path) {
-			apr_finfo_t finfo;
-			apr_file_t *grammar_file;
-			apt_str_t *content = &mrcp_message->body;
 
-			if(apr_file_open(&grammar_file,grammar_file_path,APR_FOPEN_READ|APR_FOPEN_BINARY,0,pool) != APR_SUCCESS) {
-				apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Open Grammar File %s",grammar_file_path);
-				return NULL;
+		char *last;
+		char *allSchemes = apr_pstrcat(pool,STANDARD_GRAMMAR_URI_SCHEMES,PROPRIETARY_GRAMMAR_URI_SCHEMES,NULL);
+		char *scheme = apr_strtok(allSchemes,",",&last);
+
+		apt_bool_t foundScheme = FALSE;
+		char *content_type = NULL;
+		do {
+			if(startswith(scheme,grammar_file_name)) {
+				// grammar URI uses a suppported URI scheme
+				apt_string_assign(&mrcp_message->body,grammar_file_name,pool);
+				content_type = apr_pstrdup(pool,"text/uri-list");
+				foundScheme = TRUE;
 			}
 
-			if(apr_file_info_get(&finfo,APR_FINFO_SIZE,grammar_file) != APR_SUCCESS) {
-				apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Get Grammar File Info %s",grammar_file_path);
+		} while((scheme = apr_strtok(NULL,",",&last)) != 0);
+
+		if(!foundScheme && startswith("<",grammar_file_name)) {
+			// grammar is special weighted grammar format
+			apt_string_assign(&mrcp_message->body,grammar_file_name,pool);
+			content_type = apr_pstrdup(pool,"text/grammar-ref-list");
+			foundScheme = TRUE;
+		}
+		else if(!foundScheme) {
+			// grammar is not URI and not weighted URI, use local file as inline grammar
+			char *grammar_file_path = apt_datadir_filepath_get(dir_layout,grammar_file_name,pool);
+
+			if(grammar_file_path) {
+				apr_finfo_t finfo;
+				apr_file_t *grammar_file;
+				apt_str_t *content = &mrcp_message->body;
+
+				if(apr_file_open(&grammar_file,grammar_file_path,APR_FOPEN_READ | APR_FOPEN_BINARY,0,pool) != APR_SUCCESS) {
+					apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Open Grammar File %s",grammar_file_path);
+					return NULL;
+				}
+
+				if(apr_file_info_get(&finfo,APR_FINFO_SIZE,grammar_file) != APR_SUCCESS) {
+					apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Get Grammar File Info %s",grammar_file_path);
+					apr_file_close(grammar_file);
+					return NULL;
+				}
+
+				content->length = (apr_size_t)finfo.size;
+				content->buf = (char*) apr_palloc(pool,content->length+1);
+				apt_log(APT_LOG_MARK,APT_PRIO_DEBUG,"Load Grammar File Content size [%"APR_SIZE_T_FMT" bytes] %s",
+					content->length,grammar_file_path);
+				if(apr_file_read(grammar_file,content->buf,&content->length) != APR_SUCCESS) {
+					apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Read Grammar File Content %s",grammar_file_path);
+					apr_file_close(grammar_file);
+					return NULL;
+				}
+				content->buf[content->length] = '\0';
 				apr_file_close(grammar_file);
-				return NULL;
-			}
 
-			content->length = (apr_size_t)finfo.size;
-			content->buf = (char*) apr_palloc(pool,content->length+1);
-			apt_log(APT_LOG_MARK,APT_PRIO_DEBUG,"Load Grammar File Content size [%"APR_SIZE_T_FMT" bytes] %s",
-				content->length,grammar_file_path);
-			if(apr_file_read(grammar_file,content->buf,&content->length) != APR_SUCCESS) {
-				apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Read Grammar File Content %s",grammar_file_path);
-				apr_file_close(grammar_file);
-				return NULL;
+				if(endsWith(grammar_file_name,".grxml") || endsWith(grammar_file_name,".xml")) {
+					content_type = apr_pstrdup(mrcp_message->pool,"application/srgs+xml");
+				}
+				// udpate note - propietary grammar content types may be added
+				/*
+				else if(endsWith(grammar_file_name,".xxx")) {
+					content_type = apr_pstrdup(mrcp_message->pool,"application/vnd.xxx.xxx");
+				}
+				*/
+				// udpate note - end proprietary grammar content types
+				else {
+					apt_log(APT_LOG_MARK,APT_PRIO_ERROR,"Unsupported grammar scheme. grammar_file_name:%s",grammar_file_name);
+					return NULL;
+				}
 			}
-			content->buf[content->length] = '\0';
-			apr_file_close(grammar_file);
 		}
 
 		/* get/allocate generic header */
 		generic_header = mrcp_generic_header_prepare(mrcp_message);
 		if(generic_header) {
 			/* set generic header fields */
-			if(mrcp_message->start_line.version == MRCP_VERSION_2) {
-				apt_string_assign(&generic_header->content_type,"application/srgs+xml",mrcp_message->pool);
+			if(foundScheme) {
+				apt_string_assign(&generic_header->content_type,content_type,mrcp_message->pool);
+			}
+			else if(mrcp_message->start_line.version == MRCP_VERSION_2) {
+				apt_string_assign(&generic_header->content_type,content_type,mrcp_message->pool);
 			}
 			else {
+				// udpate note - i'm not sure this is still backwards compatible with MRCP v1
 				apt_string_assign(&generic_header->content_type,"application/grammar+xml",mrcp_message->pool);
 			}
+
 			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_CONTENT_TYPE);
-			apt_string_assign(&generic_header->content_id,"demo-grammar",mrcp_message->pool);
+			char *content_id = apr_psprintf(mrcp_message->pool,"demo-grammar-%d",i);
+			apt_string_assign(&generic_header->content_id,content_id,mrcp_message->pool);
 			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_CONTENT_ID);
 		}
 	}
@@ -346,45 +377,64 @@ static mrcp_message_t* define_grammar_message_create(asr_session_t *asr_session,
 }
 
 /** Create RECOGNIZE request */
-static mrcp_message_t* recognize_message_create(asr_session_t *asr_session)
+static mrcp_message_t* recognize_message_create(asr_session_t *asr_session, int uriCount, float weights[])
 {
+	if (weights == NULL) return NULL;
+
 	/* create MRCP message */
 	mrcp_message_t *mrcp_message = mrcp_application_message_create(
 										asr_session->mrcp_session,
 										asr_session->mrcp_channel,
 										RECOGNIZER_RECOGNIZE);
 	if(mrcp_message) {
-		mrcp_recog_header_t *recog_header;
-		mrcp_generic_header_t *generic_header;
-		/* get/allocate generic header */
-		generic_header = mrcp_generic_header_prepare(mrcp_message);
+		mrcp_recog_header_t *recog_header = mrcp_resource_header_prepare(mrcp_message);
+		mrcp_generic_header_t *generic_header = mrcp_generic_header_prepare(mrcp_message);
 		if(generic_header) {
+			int i = 0;
+			char *content_id = NULL;
+			char *body = "";
+
 			/* set generic header fields */
-			apt_string_assign(&generic_header->content_type,"text/uri-list",mrcp_message->pool);
+			apt_bool_t useWeights = FALSE;
+			for(i = 0; i < uriCount; i++) {
+				if(weights[i] != 1.0) {
+					useWeights = TRUE;
+					break;
+				}
+			}
+
+			if(useWeights) {
+				apt_string_assign(&generic_header->content_type,"text/grammar-ref-list",mrcp_message->pool);
+			}
+			else {
+				apt_string_assign(&generic_header->content_type,"text/uri-list",mrcp_message->pool);
+			}
 			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_CONTENT_TYPE);
-			/* set message body */
-			apt_string_assign(&mrcp_message->body,"session:demo-grammar",mrcp_message->pool);
+
+			for(i = 0; i < uriCount; i++) {
+				/* set message body */
+				if(useWeights) {
+					content_id = apr_psprintf(mrcp_message->pool,"<session:demo-grammar-%d>;weight=\"%.2f\"\n",i,weights[i]);
+				}
+				else {
+					content_id = apr_psprintf(mrcp_message->pool,"session:demo-grammar-%d\n",i);
+				}
+				if (content_id == NULL) {
+					apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed create  content_id. i: %d",i);
+					return NULL;
+				}
+				body = apr_pstrcat(mrcp_message->pool,body,content_id,NULL);
+			}
+			apt_string_assign(&mrcp_message->body,body,mrcp_message->pool);
 		}
 		/* get/allocate recognizer header */
-		recog_header = mrcp_resource_header_prepare(mrcp_message);
 		if(recog_header) {
 			if(mrcp_message->start_line.version == MRCP_VERSION_2) {
 				/* set recognizer header fields */
 				recog_header->cancel_if_queue = FALSE;
 				mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_CANCEL_IF_QUEUE);
 			}
-			recog_header->no_input_timeout = 5000;
-			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_NO_INPUT_TIMEOUT);
-			recog_header->recognition_timeout = 20000;
-			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_RECOGNITION_TIMEOUT);
-			recog_header->speech_complete_timeout = 400;
-			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_COMPLETE_TIMEOUT);
-			recog_header->dtmf_term_timeout = 3000;
-			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_TERM_TIMEOUT);
-			recog_header->dtmf_interdigit_timeout = 3000;
-			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_INTERDIGIT_TIMEOUT);
-			recog_header->confidence_threshold = 0.5f;
-			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_CONFIDENCE_THRESHOLD);
+			// Session Parameters are set in asr_session_set_param(). Use a parmeters file to override the ASR defaults
 			recog_header->start_input_timers = TRUE;
 			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_START_INPUT_TIMERS);
 		}
@@ -392,8 +442,8 @@ static mrcp_message_t* recognize_message_create(asr_session_t *asr_session)
 	return mrcp_message;
 }
 
-/** Get NLSML result */
-static const char* nlsml_result_get(mrcp_message_t *message)
+/** Get NLSML result, exported for usage with external tools. */
+ASR_CLIENT_DECLARE(const char*) nlsml_result_get(mrcp_message_t *message)
 {
 	nlsml_interpretation_t *interpretation;
 	nlsml_instance_t *instance;
@@ -401,13 +451,13 @@ static const char* nlsml_result_get(mrcp_message_t *message)
 	if(!result) {
 		return NULL;
 	}
-	
+
 	/* get first interpretation */
 	interpretation = nlsml_first_interpretation_get(result);
 	if(!interpretation) {
 		return NULL;
 	}
-	
+
 	/* get first instance */
 	instance = nlsml_interpretation_first_instance_get(interpretation);
 	if(!instance) {
@@ -526,7 +576,7 @@ ASR_CLIENT_DECLARE(asr_session_t*) asr_session_create(asr_engine_t *engine, cons
 		mrcp_application_session_destroy(session);
 		return NULL;
 	}
-	
+
 	asr_session->engine = engine;
 	asr_session->mrcp_session = session;
 	asr_session->mrcp_channel = channel;
@@ -563,20 +613,98 @@ ASR_CLIENT_DECLARE(asr_session_t*) asr_session_create(asr_engine_t *engine, cons
 	return asr_session;
 }
 
+// udpate note - break up original asr_session_file_recognize()
+// into:
+//   asr_session_file_recognize()
+//   asr_session_define_grammar() - lets the function be called multiple times
+//   asr_session_file_recognize_send() - lets us test some stuff in beteween send and receieve
+//   asr_session_file_recognize_receive() - lets us test some stuff in beteween send and receieve
+
 /** Initiate recognition based on specified grammar and input file */
 ASR_CLIENT_DECLARE(const char*) asr_session_file_recognize(
 									asr_session_t *asr_session, 
 									const char *grammar_file, 
-									const char *input_file)
+									const char *input_file,
+									const char* set_params_file,
+									apt_bool_t sendSetParams,
+									apt_bool_t sendGetParams)
 {
-	const mrcp_app_message_t *app_message;
+	int uriCount = 0;
+	float weights[MAX_URIS];
+	int i = 0;
+	char *temp_grammar_uri_list = apr_pstrdup(asr_session->mrcp_session->pool,grammar_file);
+	char *last;
+	char *grammar_uri;
+	char *grammar_uri_with_params = apr_strtok(temp_grammar_uri_list,",",&last);
+	char *weight;
+	char *lastWeight;
+	char *lastGrammar;
+
+	for(i = 0; i < MAX_URIS; i++)
+		weights[i] = 1.0f;
+
+	do {
+		if(grammar_uri_with_params[0] == '<') {
+			grammar_uri = apr_strtok(grammar_uri_with_params,"<>",&lastGrammar);
+			weight = apr_strtok(lastGrammar,"\"",&lastWeight);
+			if(weight == NULL) {
+				weights[uriCount] = 1.0f;
+			}
+			else {
+				lastWeight[strlen(lastWeight)-1] = '\0';
+				weights[uriCount] = (float) atof(lastWeight);
+			}
+		}
+		else {
+			grammar_uri = grammar_uri_with_params;
+		}
+
+		if(asr_session_define_grammar(asr_session,grammar_uri,uriCount)) {
+			uriCount++;
+		}
+		else {
+			apt_log(APT_LOG_MARK,APT_PRIO_ERROR,"Define grammar failed for %s.",grammar_uri);
+			uriCount++;
+		}
+
+		if (uriCount == MAX_URIS) {
+			apt_log(APT_LOG_MARK,APT_PRIO_ERROR,"URI list has too many URIs.");
+			return NULL;
+		}
+	} while((grammar_uri_with_params = apr_strtok(NULL,",",&last)) != 0);
+
+
+	asr_session_file_recognize_send(asr_session,grammar_file,input_file,uriCount,weights,set_params_file,sendSetParams);
+	do {
+		mrcp_recognizer_event_id event_id = asr_session_file_recognize_receive(asr_session);
+
+		if(event_id == RECOGNIZER_START_OF_INPUT) {
+			apt_log(APT_LOG_MARK,APT_PRIO_DEBUG,"Receieved Start-of-Input");
+		}
+		else if(event_id == RECOGNIZER_RECOGNITION_COMPLETE) {
+			apt_log(APT_LOG_MARK,APT_PRIO_DEBUG,"Receieved Recognition-Complete");
+		}
+	} while(!asr_session->recog_complete);
+	/* Get results */
+	return nlsml_result_get(asr_session->recog_complete);
+}
+
+/* Exported for usage with external tools. */
+ASR_CLIENT_DECLARE(apt_bool_t) asr_session_define_grammar(
+								asr_session_t *asr_session,
+								const char *grammar_uri,
+								int uriCount)
+{
+	const mrcp_app_message_t *app_message = NULL;
 	mrcp_message_t *mrcp_message;
 
-	app_message = NULL;
-	mrcp_message = define_grammar_message_create(asr_session,grammar_file);
+	mrcp_channel_t *client_channel = (mrcp_channel_t*) asr_session->mrcp_channel;
+	apt_log(APT_LOG_MARK,APT_PRIO_DEBUG,"Begin asr_session_define_grammar. session: %s. grammar_uri: %s. uriCount: %d",client_channel->session->id.buf,grammar_uri,uriCount);
+
+	mrcp_message = define_grammar_message_create(asr_session,grammar_uri,uriCount);
 	if(!mrcp_message) {
 		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Create DEFINE-GRAMMAR Request");
-		return NULL;
+		return FALSE;
 	}
 
 	/* Send DEFINE-GRAMMAR request and wait for the response */
@@ -589,20 +717,293 @@ ASR_CLIENT_DECLARE(const char*) asr_session_file_recognize(
 	apr_thread_mutex_unlock(asr_session->mutex);
 
 	if(mrcp_response_check(app_message,MRCP_REQUEST_STATE_COMPLETE) == FALSE) {
-		return NULL;
+		return FALSE;
 	}
+
+	mrcp_status_code_e status_code = app_message->control_message->start_line.status_code;
+	return (MRCP_STATUS_CODE_SUCCESS == status_code || MRCP_STATUS_CODE_SUCCESS_WITH_IGNORE == status_code);
+}
+
+static void *set_individual_param(mrcp_message_t *mrcp_message, mrcp_recog_header_t *recog_header, const char* pname, const char* pvalue)
+{
+	int no_input_timeout, n_best_list_length, recognition_timeout;
+	float confidence_threshold, sensitivity_level, speed_vs_accuracy;
+	int speech_complete_timeout, speech_incomplete_timeout, dtmf_interdigit_timeout, dtmf_term_timeout;
+	int hotword_max_duration, hotword_min_duration;
+	char *stopptr;
+
+	if(apr_strnatcasecmp(pname,"Confidence-Threshold") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_CONFIDENCE_THRESHOLD);
+		}
+		else {
+			confidence_threshold = strtof(pvalue,&stopptr);
+			recog_header->confidence_threshold = confidence_threshold;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_CONFIDENCE_THRESHOLD);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Sensitivity-Level") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SENSITIVITY_LEVEL);
+		}
+		else {
+			sensitivity_level = strtof(pvalue,&stopptr);
+			recog_header->sensitivity_level = sensitivity_level;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SENSITIVITY_LEVEL);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Speed-Vs-Accuracy") == 0) {
+		if(0 == strlen(pvalue))	{
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SPEED_VS_ACCURACY);
+		}
+		else {
+			speed_vs_accuracy = strtof(pvalue,&stopptr);
+			recog_header->speed_vs_accuracy = speed_vs_accuracy;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SPEED_VS_ACCURACY);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"N-Best-List-Length") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_N_BEST_LIST_LENGTH);
+		}
+		else {
+			n_best_list_length = atoi(pvalue);
+			recog_header->n_best_list_length = n_best_list_length;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_N_BEST_LIST_LENGTH);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"No-Input-Timeout") == 0) {
+		if(0 == strlen(pvalue))	{
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_NO_INPUT_TIMEOUT);
+		}
+		else {
+			no_input_timeout = atoi(pvalue);
+			recog_header->no_input_timeout = no_input_timeout;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_NO_INPUT_TIMEOUT);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Recognition-Timeout") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_RECOGNITION_TIMEOUT);
+		}
+		else {
+			recognition_timeout = atoi(pvalue);
+			recog_header->recognition_timeout = recognition_timeout;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_RECOGNITION_TIMEOUT);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Speech-Complete-Timeout") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_COMPLETE_TIMEOUT);
+		}
+		else {
+			speech_complete_timeout = atoi(pvalue);
+			recog_header->speech_complete_timeout = speech_complete_timeout;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_COMPLETE_TIMEOUT);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Speech-Incomplete-Timeout") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_INCOMPLETE_TIMEOUT);
+		}
+		else {
+			speech_incomplete_timeout = atoi(pvalue);
+			recog_header->speech_incomplete_timeout = speech_incomplete_timeout;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_INCOMPLETE_TIMEOUT);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"DTMF-Interdigit-Timeout") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_INTERDIGIT_TIMEOUT);
+		}
+		else {
+			dtmf_interdigit_timeout = atoi(pvalue);
+			recog_header->dtmf_interdigit_timeout = dtmf_interdigit_timeout;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_INTERDIGIT_TIMEOUT);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"DTMF-Term-Timeout") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_TERM_TIMEOUT);
+		}
+		else {
+			dtmf_term_timeout = atoi(pvalue);
+			recog_header->dtmf_term_timeout = dtmf_term_timeout;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_TERM_TIMEOUT);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"DTMF-Term-Char") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_TERM_CHAR);
+		}
+		else {
+			recog_header->dtmf_term_char = pvalue[0];
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_DTMF_TERM_CHAR);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Speech-Language") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_LANGUAGE);
+		}
+		else {
+			apt_string_assign(&recog_header->speech_language,pvalue,mrcp_message->pool);
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_SPEECH_LANGUAGE);
+		}
+	}
+
+	if(mrcp_message->start_line.version == MRCP_VERSION_2 && apr_strnatcasecmp(pname,"Recognition-Mode") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_RECOGNITION_MODE);
+		}
+		else {
+			apt_string_assign(&recog_header->recognition_mode,pvalue,mrcp_message->pool);
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_RECOGNITION_MODE);
+		}
+	}
+	if(mrcp_message->start_line.version == MRCP_VERSION_2 && apr_strnatcasecmp(pname,"Hotword-Max-Duration") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_HOTWORD_MAX_DURATION);
+		}
+		else {
+			hotword_max_duration = atoi(pvalue);
+			recog_header->hotword_max_duration = hotword_max_duration;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_HOTWORD_MAX_DURATION);
+		}
+	}
+	if(mrcp_message->start_line.version == MRCP_VERSION_2 && apr_strnatcasecmp(pname, "Hotword-Min-Duration") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_resource_header_name_property_add(mrcp_message,RECOGNIZER_HEADER_HOTWORD_MIN_DURATION);
+		}
+		else {
+			hotword_min_duration = atoi(pvalue);
+			recog_header->hotword_min_duration = hotword_min_duration;
+			mrcp_resource_header_property_add(mrcp_message,RECOGNIZER_HEADER_HOTWORD_MIN_DURATION);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Logging-Tag") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_LOGGING_TAG);
+		}
+		else {
+			mrcp_generic_header_t *generic_header = mrcp_generic_header_prepare(mrcp_message);
+			apt_string_assign(&generic_header->logging_tag,pvalue,mrcp_message->pool);
+			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_LOGGING_TAG);
+		}
+	}
+	if(apr_strnatcasecmp(pname,"Vendor-Specific-Parameters") == 0) {
+		if(0 == strlen(pvalue)) {
+			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_VENDOR_SPECIFIC_PARAMS);
+		}
+		else {
+			char *val;
+			char *last;
+			char *newValue = apr_pstrdup(mrcp_message->pool,pvalue);
+
+			mrcp_generic_header_t *generic_header = mrcp_generic_header_prepare(mrcp_message);
+			generic_header->vendor_specific_params = apt_pair_array_create(1,mrcp_message->pool);
+
+			val = apr_strtok(newValue,";",&last);
+			if (val != NULL) {
+				do {
+					char *vspName;
+					char *vspValue;
+					char *vspLast;
+					apr_collapse_spaces(val,val);
+					vspName = apr_strtok(val,"=",&vspLast);
+					vspValue = apr_strtok(NULL,"=",&vspLast);
+
+					apt_str_t aprVspName;
+					apt_str_t aprVspValue;
+					apt_string_set(&aprVspName,vspName);
+					apt_string_set(&aprVspValue,vspValue);
+					apt_pair_array_append(generic_header->vendor_specific_params,&aprVspName,&aprVspValue,mrcp_message->pool);
+				} while ((val = apr_strtok(NULL,";",&last)) != 0);
+			}
+
+			mrcp_generic_header_property_add(mrcp_message,GENERIC_HEADER_VENDOR_SPECIFIC_PARAMS);
+		}
+	}
+	return NULL;
+}
+
+
+static apt_bool_t set_param_from_file(
+								asr_session_t *asr_session,
+								const char *set_params_file,
+								mrcp_message_t *mrcp_message,
+								mrcp_recog_header_t *recog_header)
+{
+	apr_pool_t * pool = asr_session->mrcp_session->pool;
+	apr_status_t rv;
+	apr_file_t *fp;
+
+	const apt_dir_layout_t *dir_layout = mrcp_application_dir_layout_get(asr_session->engine->mrcp_app);
+	char *param_file_path = apt_datadir_filepath_get(dir_layout,set_params_file,pool);
+	if(set_params_file != NULL) {
+		if((rv = apr_file_open(&fp,param_file_path,APR_FOPEN_READ,APR_OS_DEFAULT,asr_session->engine->pool)) != APR_SUCCESS) {
+			apt_log(APT_LOG_MARK,APT_PRIO_ERROR,"Failed to open file for SET-PARAMS. file: %s",set_params_file);
+			return FALSE;
+		}
+
+		char *str = apr_palloc(pool,LINE_BUFFER);
+		do {
+			char *val;
+			char *last;
+
+			rv = apr_file_gets(str,LINE_BUFFER,fp);
+			if(str != NULL) {
+				val = apr_strtok(str,":",&last);
+				if (val != NULL) {
+					const char *pname = NULL, *pvalue = NULL;
+					apr_collapse_spaces(val,val);
+					pname = val;
+					while (val && pvalue == NULL) {
+						val = apr_strtok(NULL,":",&last);
+						apr_collapse_spaces(val,val);
+						pvalue = val;
+					}
+
+					set_individual_param(mrcp_message,recog_header,pname,pvalue);
+				}
+			}
+		} while(rv != APR_EOF);
+		apr_file_close(fp);
+
+	}
+	return TRUE;
+}
+
+/* Exported for usage with external tools. */
+ASR_CLIENT_DECLARE(apt_bool_t) asr_session_file_recognize_send(
+								asr_session_t *asr_session,
+								const char *grammar_file,
+								const char *input_file,
+								int uriCount,
+								float weights[],
+								const char *set_params_file,
+								apt_bool_t sendSetParams)
+{
+	const mrcp_app_message_t *app_message = NULL;
+	mrcp_message_t *mrcp_message;
+
+	mrcp_channel_t *client_channel = (mrcp_channel_t*) asr_session->mrcp_channel;
+	apt_log(APT_LOG_MARK,APT_PRIO_DEBUG,"Begin asr_session_file_recognize_send. session: %s. input_file: %s,grammar_file: %s",client_channel->session->id.buf, input_file,grammar_file == NULL ? "(null)" : grammar_file);
 
 	/* Reset prev recog result (if any) */
 	asr_session->recog_complete = NULL;
 
-	app_message = NULL;
-	mrcp_message = recognize_message_create(asr_session);
+	mrcp_message = recognize_message_create(asr_session,uriCount,weights);
 	if(!mrcp_message) {
 		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Create RECOGNIZE Request");
-		return NULL;
+		return FALSE;
+	}
+	// TODO - add in headers if Set-Params is not used.
+	if(!sendSetParams && set_params_file != NULL) {
+		mrcp_recog_header_t *recog_header = mrcp_resource_header_prepare(mrcp_message);
+		set_param_from_file(asr_session,set_params_file,mrcp_message,recog_header);
 	}
 
-	/* Send RECOGNIZE request and wait for the response */
+	/* Send RECOGNIZE request */
 	apr_thread_mutex_lock(asr_session->mutex);
 	if(mrcp_application_message_send(asr_session->mrcp_session,asr_session->mrcp_channel,mrcp_message) == TRUE) {
 		apr_thread_cond_wait(asr_session->wait_object,asr_session->mutex);
@@ -612,49 +1013,56 @@ ASR_CLIENT_DECLARE(const char*) asr_session_file_recognize(
 	apr_thread_mutex_unlock(asr_session->mutex);
 
 	if(mrcp_response_check(app_message,MRCP_REQUEST_STATE_INPROGRESS) == FALSE) {
-		return NULL;
+		return FALSE;
 	}
-	
+
 	/* Open input file and start streaming */
 	asr_session->input_mode = INPUT_MODE_FILE;
 	if(asr_input_file_open(asr_session,input_file) == FALSE) {
-		return NULL;
+		return FALSE;
 	}
 	asr_session->streaming = TRUE;
 
-	/* Wait for events either START-OF-INPUT or RECOGNITION-COMPLETE */
-	do {
-		apr_thread_mutex_lock(asr_session->mutex);
-		app_message = NULL;
-		if(apr_thread_cond_timedwait(asr_session->wait_object,asr_session->mutex, 60 * 1000000) != APR_SUCCESS) {
-			apr_thread_mutex_unlock(asr_session->mutex);
-			return NULL;
-		}
-		app_message = asr_session->app_message;
-		asr_session->app_message = NULL;
-		apr_thread_mutex_unlock(asr_session->mutex);
-
-		mrcp_message = mrcp_event_get(app_message);
-		if(mrcp_message && mrcp_message->start_line.method_id == RECOGNIZER_RECOGNITION_COMPLETE) {
-			asr_session->recog_complete = mrcp_message;
-		}
-	}
-	while(!asr_session->recog_complete);
-
-	/* Get results */
-	return nlsml_result_get(asr_session->recog_complete);
+	return TRUE;
 }
 
+/* Exported for usage with external tools. */
+ASR_CLIENT_DECLARE(mrcp_recognizer_event_id) asr_session_file_recognize_receive(asr_session_t *asr_session)
+{
+	const mrcp_app_message_t *app_message = NULL;
+	mrcp_message_t *mrcp_message;
+
+	apr_thread_mutex_lock(asr_session->mutex);
+	if(apr_thread_cond_timedwait(asr_session->wait_object,asr_session->mutex,60 * 1000000) != APR_SUCCESS) {
+		apr_thread_mutex_unlock(asr_session->mutex);
+		return RECOGNIZER_EVENT_COUNT;
+	}
+	app_message = asr_session->app_message;
+
+	asr_session->app_message = NULL;
+	apr_thread_mutex_unlock(asr_session->mutex);
+
+	mrcp_message = mrcp_event_get(app_message);
+
+	if(mrcp_message && mrcp_message->start_line.method_id == RECOGNIZER_START_OF_INPUT) {
+		apt_log(APT_LOG_MARK,APT_PRIO_INFO,"START-OF-INPUT received");
+	}
+	if(mrcp_message && mrcp_message->start_line.method_id == RECOGNIZER_RECOGNITION_COMPLETE) {
+		apt_log(APT_LOG_MARK,APT_PRIO_INFO,"RECOGNTION-COMPLETE received");
+		asr_session->recog_complete = mrcp_message;
+	}
+
+	return mrcp_message->start_line.method_id;
+}
+
+// udpate note - is this ever used? Should it be removed?
 /** Initiate recognition based on specified grammar and input stream */
 ASR_CLIENT_DECLARE(const char*) asr_session_stream_recognize(
 									asr_session_t *asr_session,
 									const char *grammar_file)
 {
-	const mrcp_app_message_t *app_message;
-	mrcp_message_t *mrcp_message;
-
-	app_message = NULL;
-	mrcp_message = define_grammar_message_create(asr_session,grammar_file);
+	const mrcp_app_message_t *app_message = NULL;
+	mrcp_message_t *mrcp_message = define_grammar_message_create(asr_session,grammar_file,1);
 	if(!mrcp_message) {
 		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Create DEFINE-GRAMMAR Request");
 		return NULL;
@@ -677,7 +1085,7 @@ ASR_CLIENT_DECLARE(const char*) asr_session_stream_recognize(
 	asr_session->recog_complete = NULL;
 
 	app_message = NULL;
-	mrcp_message = recognize_message_create(asr_session);
+	mrcp_message = recognize_message_create(asr_session,1,NULL);
 	if(!mrcp_message) {
 		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Create RECOGNIZE Request");
 		return NULL;
@@ -698,7 +1106,7 @@ ASR_CLIENT_DECLARE(const char*) asr_session_stream_recognize(
 
 	/* Reset media buffer */
 	mpf_frame_buffer_restart(asr_session->media_buffer);
-	
+
 	/* Set input mode and start streaming */
 	asr_session->input_mode = INPUT_MODE_STREAM;
 	asr_session->streaming = TRUE;
@@ -726,6 +1134,7 @@ ASR_CLIENT_DECLARE(const char*) asr_session_stream_recognize(
 	return nlsml_result_get(asr_session->recog_complete);
 }
 
+// udpate note - is this ever used? Should it be removed?
 /** Write audio frame to recognize */
 ASR_CLIENT_DECLARE(apt_bool_t) asr_session_stream_write(
 									asr_session_t *asr_session,
@@ -756,3 +1165,136 @@ ASR_CLIENT_DECLARE(apt_bool_t) asr_engine_log_priority_set(apt_log_priority_e lo
 {
 	return apt_log_priority_set(log_priority);
 }
+
+
+
+/** Handle MRCP headers (Parameters) **/
+
+/** Create SET-PARAM request */
+static mrcp_message_t* set_param_message_create(
+							asr_session_t *asr_session,
+							const char *set_params_file,
+							const char* param_name,
+							const char *param_value)
+{
+	mrcp_message_t *mrcp_message = NULL;
+
+	if(set_params_file == NULL && param_name == NULL) {
+		return NULL;
+	}
+
+	/* create MRCP message */
+	mrcp_message = mrcp_application_message_create(asr_session->mrcp_session,asr_session->mrcp_channel,RECOGNIZER_SET_PARAMS);
+	if(mrcp_message) {
+		mrcp_recog_header_t *recog_header = mrcp_resource_header_prepare(mrcp_message);
+		if(recog_header) {
+			if(set_params_file != NULL) {
+				set_param_from_file(asr_session,set_params_file,mrcp_message,recog_header);
+			}
+			else {
+				set_individual_param(mrcp_message,recog_header,param_name,param_value);
+			}
+		}
+	}
+	return mrcp_message;
+}
+
+/** Create GET-PARAM request */
+static mrcp_message_t* get_param_message_create(asr_session_t *asr_session)
+{
+	return mrcp_application_message_create(asr_session->mrcp_session,asr_session->mrcp_channel,RECOGNIZER_GET_PARAMS);
+}
+
+ASR_CLIENT_DECLARE(apt_bool_t) asr_session_set_param(
+							asr_session_t *asr_session,
+							const char* set_params_file,
+							const char* param_name,
+							const char* param_value)
+{
+	const mrcp_app_message_t *app_message = NULL;
+	mrcp_message_t *mrcp_message = set_param_message_create(asr_session,set_params_file,param_name,param_value);
+
+	if(!mrcp_message) {
+		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Create SET-PARAMS Request");
+		return FALSE;
+	}
+
+	/* Send SET-PARAMS request and wait for the response */
+	apr_thread_mutex_lock(asr_session->mutex);
+	if(mrcp_application_message_send(asr_session->mrcp_session,asr_session->mrcp_channel,mrcp_message) == TRUE) {
+		apr_thread_cond_wait(asr_session->wait_object,asr_session->mutex);
+		app_message = asr_session->app_message;
+		asr_session->app_message = NULL;
+	}
+	apr_thread_mutex_unlock(asr_session->mutex);
+
+	if(mrcp_response_check(app_message,MRCP_REQUEST_STATE_COMPLETE) == FALSE) {
+		return FALSE;
+	}
+
+	mrcp_status_code_e status_code = app_message->control_message->start_line.status_code;
+	return (MRCP_STATUS_CODE_SUCCESS == status_code || MRCP_STATUS_CODE_SUCCESS_WITH_IGNORE == status_code);
+}
+
+static void initialize_parameter_set(asr_session_t *asr_session, ParameterSet *p)
+{
+	if(asr_session->app_message->message_type == MRCP_APP_MESSAGE_TYPE_CONTROL) {
+		mrcp_recog_header_t *recog_header = mrcp_resource_header_get(asr_session->app_message->control_message);
+
+		p->confidence_threshold = recog_header->confidence_threshold;
+		p->sensitivity_level = recog_header->sensitivity_level;
+		p->speed_vs_accuracy = recog_header->speed_vs_accuracy;
+		p->n_best_list_length = (long)recog_header->n_best_list_length;
+		p->no_input_timeout = (long)recog_header->no_input_timeout;
+		p->recognition_timeout = (long)recog_header->recognition_timeout;
+
+		p->recognizer_context_block = recog_header->recognizer_context_block.buf;
+
+		p->speech_complete_timeout = (long) recog_header->speech_complete_timeout;
+		p->speech_incomplete_timeout = (long) recog_header->speech_incomplete_timeout;
+		p->dtmf_interdigit_timeout = (long) recog_header->dtmf_interdigit_timeout;
+		p->dtmf_term_timeout = (long) recog_header->dtmf_term_timeout;
+		p->dtmf_term_char = recog_header->dtmf_term_char;
+		p->save_waveform = recog_header->save_waveform;
+
+		p->speech_language = recog_header->speech_language.buf;
+		p->media_type = recog_header->media_type.buf;
+		p->recognition_mode = recog_header->recognition_mode.buf;
+
+		p->hotword_max_duration = (long) recog_header->hotword_max_duration;
+		p->hotword_min_duration = (long) recog_header->hotword_min_duration;
+		p->dtmf_buffer_time = (long) recog_header->dtmf_buffer_time;
+		p->early_no_match = recog_header->early_no_match;
+	}
+}
+
+ASR_CLIENT_DECLARE(ParameterSet*) asr_session_get_all_params(asr_session_t *asr_session)
+{
+	ParameterSet *p = NULL;
+	const mrcp_app_message_t *app_message = NULL;
+	apr_pool_t *pool = mrcp_application_session_pool_get(asr_session->mrcp_session);
+	mrcp_message_t *mrcp_message = get_param_message_create(asr_session);
+	if(!mrcp_message) {
+		apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Failed to Create GET-PARAMS Request");
+		return NULL;
+	}
+
+	apr_thread_mutex_lock(asr_session->mutex);
+	if(mrcp_application_message_send(asr_session->mrcp_session,asr_session->mrcp_channel,mrcp_message) == TRUE) {
+		apr_thread_cond_wait(asr_session->wait_object,asr_session->mutex);
+		app_message = asr_session->app_message;
+
+	}
+	apr_thread_mutex_unlock(asr_session->mutex);
+
+	if(mrcp_response_check(app_message,MRCP_REQUEST_STATE_COMPLETE) == FALSE) {
+		return NULL;
+	}
+
+	p = apr_palloc(pool, sizeof(ParameterSet));
+	initialize_parameter_set(asr_session, p);
+	asr_session->app_message = NULL;
+
+	return p;
+}
+


### PR DESCRIPTION
This is the PR corresponding to #246. I tried to create a minimal patch without any unnecessary whitespace modifications. I also tried to be as close as possible to @achaloyan's surrounding coding style/conventions.

There's no logical changes to the code provided in #246. This patch compiles without any warnings using `gcc` 9.1.1 on Linux with `maintainer-mode` enabled. Please note that I haven't tested the resulting asrclient (besides of just starting/exiting it).

It would be great if the original author @michaelplevy could verify the Windows-compatibility as well as the correct functionality.