### PR TITLE
Allow disabling the Sofia SIP SDP Offer/Answer Engine Module

### DIFF
--- a/conf/unimrcpserver.xml
+++ b/conf/unimrcpserver.xml
@@ -44,6 +44,13 @@
       <sip-port>8060</sip-port>
       <sip-transport>udp,tcp</sip-transport>
       <!-- <force-destination>true</force-destination> -->
+      <!--
+        This parameter can be used to disable the Sofia SIP SDP Offer/Answer Engine Module (soa).
+        This should only be done when dynamic payload type negotiation is needed with MRCPv2 AND
+        the clients only use the 'Basic Call' SDP Offer/Answer scenario. More complex scenarions
+        will most probably not work with soa disabled.
+      -->
+      <!-- <disable-soa>true</disable-soa> -->
       <ua-name>UniMRCP SofiaSIP</ua-name>
       <sdp-origin>UniMRCPServer</sdp-origin>
       <!-- <sip-t1>500</sip-t1> -->

--- a/conf/unimrcpserver.xsd
+++ b/conf/unimrcpserver.xsd
@@ -57,6 +57,7 @@
                     <xsd:element name="sip-port" type="xsd:short" />
                     <xsd:element name="sip-transport" type="xsd:string" />
                     <xsd:element name="force-destination" type="xsd:boolean" default="false" minOccurs="0" />
+                    <xsd:element name="disable-soa" type="xsd:boolean" default="false" minOccurs="0" />
                     <xsd:element name="ua-name" type="xsd:string" minOccurs="0" />
                     <xsd:element name="sdp-origin" type="xsd:string" minOccurs="0" />
                     <xsd:element name="sip-t1" type="xsd:long" minOccurs="0" />
@@ -275,3 +276,4 @@
     </xsd:complexType>
   </xsd:element>
 </xsd:schema>
+

--- a/modules/mrcp-sofiasip/include/mrcp_sofiasip_server_agent.h
+++ b/modules/mrcp-sofiasip/include/mrcp_sofiasip_server_agent.h
@@ -49,6 +49,11 @@ struct mrcp_sofia_server_config_t {
 	/** Force destination IP address. Should be used only in case 
 	SDP contains incorrect connection address (local IP address behind NAT) */
 	apt_bool_t force_destination;
+	/** Disable the Sofia SIP SDP Offer/Answer Engine Module (soa). Should
+	only be used if dynamic payload type negotiation is needed AND you know
+	that your clients will only use the 'Basic Call' SDP Offer/Answer
+	scenario. */
+	apt_bool_t disable_soa;
 	/** SIP T1 timer */
 	apr_size_t sip_t1;
 	/** SIP T2 timer */

--- a/platforms/libunimrcp-server/src/unimrcp_server.c
+++ b/platforms/libunimrcp-server/src/unimrcp_server.c
@@ -393,6 +393,11 @@ static apt_bool_t unimrcp_server_sip_uas_load(unimrcp_server_loader_t *loader, c
 					config->tport_dump_file = cdata_copy(elem,loader->pool);
 			}
 		}
+		else if(strcasecmp(elem->name,"disable-soa") == 0) {
+			if(is_cdata_valid(elem) == TRUE) {
+				config->disable_soa = cdata_bool_get(elem);
+			}
+		}
 		else {
 			apt_log(APT_LOG_MARK,APT_PRIO_WARNING,"Unknown Element <%s>",elem->name);
 		}


### PR DESCRIPTION
This fixes the Sofia-SIP-based payload type negotiation (issue #248) by disabling the builtin
SOA module for SDP answers.

I tested the fix with the builtin `demorecog` plugin.