### PR TITLE
Link tracing logging to main apt_log() via macros

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,38 @@
+Changes for UniMRCP: develop
+
+  APR-toolkit library
+
+  *
+
+  MPF library
+
+  *
+
+  MRCP common library
+
+  *
+
+  MRCP server library
+
+  *
+
+  RTSP library
+
+  *
+
+  Sofia-SIP module (MRCPv2 agent)
+
+  *
+
+  UMC sample application
+
+  *
+
+  Miscellaneous
+
+  *
+
+
 Changes for UniMRCP-1.6.0
 
   APR-toolkit library

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,7 @@ Changes for UniMRCP: develop
 
   MPF library
 
-  *
+  * Feature: When tracing is set to a new mode of "3", send tracing logs directly to apt_log() using macro expansion. [#254](https://github.com/unispeech/unimrcp/pull/254)
 
   MRCP common library
 

--- a/libs/mpf/src/mpf_jitter_buffer.c
+++ b/libs/mpf/src/mpf_jitter_buffer.c
@@ -21,6 +21,9 @@
 #define JB_TRACE printf
 #elif ENABLE_JB_TRACE == 2
 #define JB_TRACE mpf_debug_output_trace
+#elif ENABLE_JB_TRACE == 3
+#define JB_TRACE(msg, args...) \
+  apt_log(MPF_LOG_MARK, APT_PRIO_INFO, msg, ##args);
 #else
 #define JB_TRACE mpf_null_trace
 #endif

--- a/libs/mpf/src/mpf_rtp_stream.c
+++ b/libs/mpf/src/mpf_rtp_stream.c
@@ -40,6 +40,9 @@
 #define RTP_TRACE printf
 #elif ENABLE_RTP_PACKET_TRACE == 2
 #define RTP_TRACE mpf_debug_output_trace
+#elif ENABLE_RTP_PACKET_TRACE == 3
+#define RTP_TRACE(msg, args...) \
+  apt_log(MPF_LOG_MARK, APT_PRIO_INFO, msg, ##args);
 #else
 #define RTP_TRACE mpf_null_trace
 #endif


### PR DESCRIPTION
When tracing is set to a new mode of "3", sends tracing logs directly to apt_log() using macro expansion.