### PR TITLE
Add TCP keepalive mechanism

### DIFF
--- a/libs/mrcpv2-transport/src/mrcp_server_connection.c
+++ b/libs/mrcpv2-transport/src/mrcp_server_connection.c
@@ -501,6 +501,10 @@ static apt_bool_t mrcp_server_agent_connection_accept(mrcp_connection_agent_t *a
 		mrcp_connection_destroy(connection);
 		return FALSE;
 	}
+	
+	/** Add TCP keepalive mechanism */
+	/** https://www.tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/ */
+	apr_socket_opt_set(connection->sock, APR_SO_KEEPALIVE, 1);
 
 	apt_log(APT_LOG_MARK,APT_PRIO_NOTICE,"Accepted TCP/MRCPv2 Connection %s",connection->id);
 	connection->agent = agent;


### PR DESCRIPTION
PR about this ticket: https://groups.google.com/forum/#!topic/unimrcp/3NCglz4dpzs
When mrcp client doesn't send TCP/FIN, unimrcp server can use TCP keepalive mechanism to detect idle session and destroy it cleanly
https://www.tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/