### PR TITLE
FIXED : reset pos.

### DIFF
--- a/libs/mrcpv2-transport/src/mrcp_client_connection.c
+++ b/libs/mrcpv2-transport/src/mrcp_client_connection.c
@@ -665,6 +665,8 @@ static apt_bool_t mrcp_client_poller_signal_process(void *obj, const apr_pollfd_
 	do {
 		msg_status = mrcp_parser_run(connection->parser,stream,&message);
 		if(mrcp_client_message_handler(connection,message,msg_status) == FALSE) {
+		    /* reset pos */
+		    apt_text_stream_scroll(stream);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
If the ASR server responds slowly, other calls on the connection will be affected.

stream will be appended.

`MRCP/2.0 94 START-OF-INPUT 1 IN-PROGRESS
Channel-Identifier: 4fee51d8028b4822@speechrecog

MRCP/2.0 94 START-OF-INPUT 1 IN-PROGRESS
Channel-Identifier: 4fee51d8028b4822@speechrecog

MRCP/2.0 94 START-OF-INPUT 1 IN-PROGRESS
Channel-Identifier: 4fee51d8028b4822@speechrecog
`